### PR TITLE
Remove grunt-rollup grunt plugin, replace with customRollup task,

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,14 +32,15 @@
     }
   ],
   "scripts": {
-      "postinstall": "npx playwright install --with-deps",
-      "test": "npx playwright test --retries=3 --workers=1"
+    "postinstall": "npx playwright install --with-deps",
+    "test": "npx playwright test --retries=3 --workers=1"
   },
   "devDependencies": {
     "@playwright/test": "^1.39.0",
     "@rollup/plugin-alias": "^5.1.1",
     "@rollup/plugin-legacy": "^3.0.2",
     "@rollup/plugin-node-resolve": "^15.2.3",
+    "@rollup/plugin-terser": "^0.4.4",
     "mapml-extension": "git+https://github.com/Maps4HTML/mapml-extension",
     "diff": "^5.1.0",
     "express": "^4.17.1",
@@ -49,11 +50,9 @@
     "grunt-contrib-copy": "~1.0.0",
     "grunt-contrib-cssmin": "^4.0.0",
     "grunt-contrib-jshint": "~3.2.0",
-    "grunt-contrib-uglify": "~5.0.0",
     "grunt-contrib-watch": "~1.1.0",
     "grunt-html": "^15.2.2",
     "grunt-prettier": "^2.2.0",
-    "grunt-rollup": "^12.0.0",
     "leaflet": "^1.9.4",
     "leaflet.locatecontrol": "^0.81.1",
     "path": "^0.12.7",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,33 @@
+const nodeResolve = require('@rollup/plugin-node-resolve');
+const alias = require('@rollup/plugin-alias');
+const loadLocalePlugin = require('./load-locales.js');
+const terser = require('@rollup/plugin-terser');
+
+module.exports = {
+  input: 'src/mapml/index.js',
+  plugins: [
+    nodeResolve(),
+    loadLocalePlugin(),
+    alias({
+      entries: [
+        {
+          find: 'leaflet',
+          replacement: 'leaflet/dist/leaflet-src.esm.js'
+        }
+      ]
+    }),
+    terser({
+        compress: true,
+        mangle: true,
+        format: {
+          comments: false
+        },
+        sourceMap: true // Maintain source maps even during minification
+      })
+  ],
+  output: {
+    file: 'dist/mapml.js',
+    format: 'esm',
+    sourcemap: true
+  }
+};


### PR DESCRIPTION
- config done via external rollup.config.js.
- Remove uglify grunt plugin, replace with terser rollup plugin (does a better job with source maps and chained minification)
- Add nrcan-basemap grunt task for sibling project to get nrcan vector tile basemap working with pmtiles.

Closes #1013 

